### PR TITLE
deleteing artobj on django admin deletes image from thearchive folder…

### DIFF
--- a/thearchiveapi/models/art.py
+++ b/thearchiveapi/models/art.py
@@ -1,5 +1,6 @@
 from django.db import models
 from cloudinary.models import CloudinaryField
+from cloudinary.uploader import destroy
 from .tag import Tag
 
 
@@ -19,6 +20,16 @@ class Art(models.Model):
     malfunction = models.BooleanField(default=False)
     tags = models.ManyToManyField(
         Tag, through='ArtTag', related_name='art', blank=True)
+
+
+    def delete(self, *args, **kwargs):
+        # Delete the Cloudinary image associated with this Art object
+        if self.pic:
+            # include folder name in the public_id
+            open_id = f'the-archive/{self.pic.public_id}'
+            destroy(open_id)
+            #destroy(self.pic.public_id)
+        super(Art, self).delete(*args, **kwargs)
 
     # @property
     # def circle_image(self):


### PR DESCRIPTION
… on cloudinary
- will have to reupload proper objects to test out 
- after uploading to `the-archive` folder, you can also delete from the folder by deleting the `art obj` on the django admin site