### PR TITLE
per book-deleted scratchsql and made Django secret key

### DIFF
--- a/scratch.sql
+++ b/scratch.sql
@@ -1,5 +1,0 @@
-SELECT * FROM thearchiveapi_art;
-
-SELECT * FROM thearchiveapi_tag;
-
-SELECT * FROM thearchiveapi_fan;

--- a/thearchive/settings.py
+++ b/thearchive/settings.py
@@ -39,7 +39,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-60&^u@4+r*0aairmq#u-s$gvvk!jp7^ip6kwvchz8f@0#&*=ec'
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
- Following book
- https://github.com/nashville-software-school/server-side-python-curriculum/blob/evening-cohorts/book-4-bangazon/chapters/HEROKU_DEPLOYMENT.md
- although I can't find the instructions for the secret key
- i ran `python3 manage.py shell -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"` 
- i put the secret key in the `.env` file so it's properly ignored. 