### PR TITLE
settings for deploy-heroku steps

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ django-cors-headers = "==3.13.0"
 pylint-django = "==2.5.3"
 gunicorn = "*"
 django-on-heroku = "*"
+cloudinary = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,8 @@ pylint = "==2.15.5"
 djangorestframework = "==3.14.0"
 django-cors-headers = "==3.13.0"
 pylint-django = "==2.5.3"
+gunicorn = "*"
+django-on-heroku = "*"
 
 [dev-packages]
 

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn thearchive.wsgi --log-file -

--- a/thearchive/settings.py
+++ b/thearchive/settings.py
@@ -39,10 +39,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
+# SECURITY WARNING: keep the secret key used in production secret! 
 SECRET_KEY = os.environ.get('SECRET_KEY')
 
-# SECURITY WARNING: don't run with debug turned on in production!
+# SECURITY WARNING: don't run with debug turned on in production! Change to False when deploying to Heroku
+# DEBUG = False
 DEBUG = True
 
 ALLOWED_HOSTS = []
@@ -149,7 +150,8 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:3000',
-    'http://127.0.0.1:3000'
+    'http://127.0.0.1:3000',
+    'www.thesonatorearchive.org',
 )
 
 FIXTURE_DIRS = [
@@ -158,7 +160,7 @@ FIXTURE_DIRS = [
 
 # Activate Django-Heroku
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
-STATIC_URL = "/static/"
+
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 #STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 

--- a/thearchive/settings.py
+++ b/thearchive/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 
 from pathlib import Path
 import os
+import django_on_heroku
 import cloudinary
 import cloudinary.uploader
 import cloudinary.api
@@ -154,3 +155,10 @@ CORS_ORIGIN_WHITELIST = (
 FIXTURE_DIRS = [
     '/thearchiveapi/fixtures/'
 ]
+
+# Activate Django-Heroku
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATIC_URL = "/static/"
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
+
+django_on_heroku.settings(locals())

--- a/thearchive/settings.py
+++ b/thearchive/settings.py
@@ -160,5 +160,6 @@ FIXTURE_DIRS = [
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = "/static/"
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
+#STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 django_on_heroku.settings(locals())


### PR DESCRIPTION
- I'm at about 7 minutes into the tutorial
- https://github.com/nashville-software-school/server-side-python-curriculum/blob/evening-cohorts/book-4-bangazon/chapters/HEROKU_DEPLOYMENT.md
- so I'm stuck at the automatic deploy setup
- hannah's video, she included pipfile.lock in the repo, but we have ours in the .gitignore file