### PR TITLE
added some additional cors config to settings

### DIFF
--- a/thearchive/settings.py
+++ b/thearchive/settings.py
@@ -65,14 +65,26 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+CORS_ALLOWED_ORIGINS = [
+    "https://the-sonatore-archive-client-08df369abde2.herokuapp.com"
+]
+
+CORS_ALLOW_METHODS = [
+    "GET",
+]
+
+CORS_ALLOW_HEADERS = [
+    "content-type",
 ]
 
 ROOT_URLCONF = 'thearchive.urls'
@@ -153,7 +165,6 @@ CORS_ORIGIN_WHITELIST = (
     'http://127.0.0.1:3000',
     'https://thesonatorearchive.org',
     'https://the-sonatore-archive-client-08df369abde2.herokuapp.com'
-    'https://the-sonatore-archive-840804772ccc.herokuapp.com'
 )
 
 FIXTURE_DIRS = [


### PR DESCRIPTION
I think there were some missing cors configuration settings that i've added, in addition to the whitelist, we need to allow requests specifically from the front end, and we need to allow the get method since thats the only method in the app so far.
kind of hard to test without merging to deploy and restarting the server.
