### PR TITLE
Deploying settings-whitelist

### DIFF
--- a/thearchive/settings.py
+++ b/thearchive/settings.py
@@ -153,7 +153,6 @@ CORS_ORIGIN_WHITELIST = (
     'http://127.0.0.1:3000',
     'https://thesonatorearchive.org',
     'https://the-sonatore-archive-client-08df369abde2.herokuapp.com'
-    'https://the-sonatore-archive-840804772ccc.herokuapp.com'
 )
 
 FIXTURE_DIRS = [


### PR DESCRIPTION
>settings.py
Whitelist
taking out the URL of the server because the server side does not need to whitelist itself