### PR TITLE
im adding the django rest root URL back to the cors origin whitelist …

### DIFF
--- a/thearchive/settings.py
+++ b/thearchive/settings.py
@@ -164,7 +164,8 @@ CORS_ORIGIN_WHITELIST = (
     'http://localhost:3000',
     'http://127.0.0.1:3000',
     'https://thesonatorearchive.org',
-    'https://the-sonatore-archive-client-08df369abde2.herokuapp.com'
+    'https://the-sonatore-archive-client-08df369abde2.herokuapp.com',
+    'https://the-sonatore-archive-840804772ccc.herokuapp.com'
 )
 
 FIXTURE_DIRS = [


### PR DESCRIPTION
…with the comma to see if it changes the 500 error
the 500: internal server error may be a cors error 